### PR TITLE
Fix Workflow library for recent PHP and Alfred versions

### DIFF
--- a/workflows.php
+++ b/workflows.php
@@ -39,8 +39,8 @@ class Workflows {
 			$this->bundle = $bundleid;
 		endif;
 
-		$this->cache = $this->home. "/Library/Caches/com.runningwithcrayons.Alfred-2/Workflow Data/".$this->bundle;
-		$this->data  = $this->home. "/Library/Application Support/Alfred 2/Workflow Data/".$this->bundle;
+		$this->cache = $this->home. "/Library/Caches/com.runningwithcrayons.Alfred/Workflow Data/".$this->bundle;
+		$this->data  = $this->home. "/Library/Application Support/Alfred/Workflow Data/".$this->bundle;
 
 		if ( !file_exists( $this->cache ) ):
 			exec("mkdir '".$this->cache."'");
@@ -195,7 +195,7 @@ class Workflows {
 						$c->addAttribute( 'valid', $b[$key] );
 					endif;
 				elseif ( $key == 'autocomplete' ):
-					$c->addAttribute( 'autocomplete', $b[$key] );
+					$c->addAttribute( 'autocomplete', $b[$key] ?? '' );
 				elseif ( $key == 'icon' ):
 					if ( substr( $b[$key], 0, 9 ) == 'fileicon:' ):
 						$val = substr( $b[$key], 9 );


### PR DESCRIPTION
[As per a user on the forums](https://www.alfredforum.com/topic/18632-php-workflow-running-but-not-printing-its-results/#comment-96975), the Workflow currently doesn’t work due to PHP deprecations. This PR fixes it and updates Alfred’s Data and Cache locations.

[Packaged Workflow for download](https://github.com/mattstein/alfred-datespan/files/9136429/Date.Span.alfredworkflow.zip).